### PR TITLE
Home : improve the way to set data after login&logout

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -73,9 +73,9 @@ export default {
     Header, Background, LoginPopup, CoursePopup
   },
   created() {
-    this.login.loginState = JSON.parse(localStorage.getItem('loginState'));
-    this.login.userName = localStorage.getItem('userName');
-    
+    // this.login.loginState = JSON.parse(localStorage.getItem('loginState'));
+    // this.login.userName = localStorage.getItem('userName');
+    this.getDataFromLocal();
   },
   data() {
     return {
@@ -90,6 +90,10 @@ export default {
     }
   },
   methods : {
+    getDataFromLocal() {
+      this.login.loginState = JSON.parse(localStorage.getItem('loginState'));
+      this.login.userName = localStorage.getItem('userName');
+    },
     loginOpen() {
       this.loginPopupState = 1;
     },
@@ -104,7 +108,7 @@ export default {
       this.coursePopupState = 0;
     },
     changeLoginState() {
-      this.$router.go(); //변경된 loginState의 값으로 세팅하기 위해 새로 고침
+      this.getDataFromLocal(); //변경된 loginState의 값으로 세팅하기 위해 새로 고침
     }
   }
 }


### PR DESCRIPTION
로그인 또는 로그아웃 후 새로고침 하여 데이터() 세팅하는 방식을
아래의 함수를 이용해서 새로고침하지 않더라도 데이터가 세팅될 수 있도록 수정
```
getDataFromLocal() {
      this.login.loginState = JSON.parse(localStorage.getItem('loginState'));
      this.login.userName = localStorage.getItem('userName');
    },
```
로그인, 로그아웃 후 위의 함수가 실행되어 loginState와 userName을 local Storage로부터 불러와서 세팅